### PR TITLE
Add missing rail directions

### DIFF
--- a/static/const.py
+++ b/static/const.py
@@ -43,6 +43,8 @@ RAIL_DIRECTION_STOPS = [
     ("2900", "2910"),  # W-wa Wschodnia      → W-wa Rembertów  (S2 specific)
     ("7903", "1907"),  # W-wa Gdańska        → Legionowo       (S9 specific)
     ("2900", "1907"),  # W-wa Wschodnia      → Legionowo       (S3 specific)
+    ("7903", "1905"),  # W-wa Gdańska        → W-wa Płudy      (S3 specific)
+    ("1907", "1910"),  # Legionowo           → Wieliszew       (S30 specific)
 ]
 
 

--- a/static/converter/platformhandler.py
+++ b/static/converter/platformhandler.py
@@ -45,6 +45,7 @@ FALLBACK_PLATFORMS: Dict[Tuple[str, str], str] = {
     ("2918", "otwock"): "2",
     ("2900", "warszawawschodnia"): "6",
     ("2900", "otwock"): "7",
+    ("4905", "pruszków"): "1",
 }
 
 


### PR DESCRIPTION
https://www.skm.warszawa.pl/03-01-2023-weekendowe-zmiany-w-kursowaniu-szybkiej-kolei-miejskiej-linii-s3/