### PR TITLE
Adding job_name extra field

### DIFF
--- a/warsaw_gtfs/gtfs.py
+++ b/warsaw_gtfs/gtfs.py
@@ -63,6 +63,7 @@ GTFS_HEADERS = {
         "wheelchair_accessible",
         "block_id",
         "block_short_name",
+        "job_name",
         "variant_code",
         "fleet_type",
     ),

--- a/warsaw_gtfs/load_json/trips.py
+++ b/warsaw_gtfs/load_json/trips.py
@@ -72,6 +72,7 @@ def parse_trip(
         extra_fields_json=compact_json(
             {
                 "block_short_name": brigade,
+                "job_name": job.name,
                 "fleet_type": fleet_type,
             }
         ),
@@ -96,7 +97,7 @@ def parse_schedules(
 def parse_jobs(data: Any) -> dict[int, Job]:
     return {
         i["id_zadania"]: Job(
-            name=i["nazwa_zadania"],
+            name=i["nazwa_zadania"] or "",
             vehicle_kind=i["id_taboru"],
         )
         for i in data["zadania"]


### PR DESCRIPTION
**Disclaimer**:
- I don't have the upstream API key, so I am not sure what exact data is provided there.

**What**:
- Export `zadania[].nazwa_zadania` (already parsed into `Job.name`, previously discarded) as a new `job_name` column in `trips.txt`.
- Coerce a null `nazwa_zadania` to `""` in `parse_jobs`, so `Job.name` holds the `str`, its annotation promises and a null can't reach the CSV (just a safety mechanism, not fully sure if needed)

**Why**:
- I hope to get the value of the operator (like MZA, Mobilis, KMŁ, etc.)

Kindly please review and/or suggest what would work better.