### PR TITLE
Data curation for 162 south-bound not to turn into Dobra

### DIFF
--- a/data_curated/shapes.json
+++ b/data_curated/shapes.json
@@ -119,6 +119,12 @@
       "to": "435801",
       "via": [52.10678, 20.96913],
       "comment": "L33 for PKP Jeziorki via Raszyńska street"
+    },
+    {
+      "from": "707904",
+      "to": "706703",
+      "via": [52.23819, 21.025393],
+      "comment": "162 and others via Topiel, not Dobra"
     }
   ],
   "ratio_overrides": [


### PR DESCRIPTION
**What**: 

Adding bus data curation for 162, the south-bound trip shouldn't turn left to Dobra, then right to Tamka, then left to Topiel. Instead go straight and turn left to Topiel.

<img width="555" height="417" alt="162" src="https://github.com/user-attachments/assets/3884aed3-3c12-47e7-9672-cb14b0e58bb8" />

**Why**:
- This is how the buses go.
- Two left-turns and turning into Tamka is problematic