### PR TITLE
Use `earth_distance_m` for shape generation distance guard

### DIFF
--- a/warsaw_gtfs/generate_shapes/config.py
+++ b/warsaw_gtfs/generate_shapes/config.py
@@ -28,7 +28,7 @@ class GraphConfig:
     """Name of a resource containing manual overrides for shape generation"""
 
     max_stop_to_node_distance: float = 100.0
-    """Max distance between a stop and its matched node in the graph."""
+    """Max distance, in meters, between a stop and its matched node in the graph."""
 
 
 @dataclass

--- a/warsaw_gtfs/generate_shapes/generator.py
+++ b/warsaw_gtfs/generate_shapes/generator.py
@@ -6,6 +6,7 @@ from math import inf
 from pathlib import Path
 
 import routx
+from impuls.tools.geo import earth_distance_m
 
 from .config import LoggingConfig
 from .model import (
@@ -75,7 +76,7 @@ class ShapeGenerator:
 
         lat, lon = self.stop_positions[stop_id]
         node = self.kd_tree.find_nearest_node(lat, lon)
-        dist = routx.earth_distance(lat, lon, node.lat, node.lon)
+        dist = earth_distance_m(lat, lon, node.lat, node.lon)
         if dist > self.max_stop_to_node_distance:
             node_id = 0
             self.logger.error(


### PR DESCRIPTION
**What**:

Fixing a bug in shape generation logic.
The guard for avoiding too much distance between a stop and a curated routing position has classic unit mismatch problem. The [routx library returns the distance in kilometers](https://docs.rs/routx/latest/routx/fn.earth_distance.html) while we compare it to a distance in meters.

**Why**:
- To be honest I don't need it for anything. Just noticed it when analyzing the code.
- Also, since the guard was effectively `> 100 km`, I suppose it didn't work in practice. So maybe you want to just remove it?

**Context**
- If you decide to make the change, I suppose subsequent runs might trigger `Stop %s is too far from nearest node` warnings.
- I couldn't verify this myself as I don't have the upstream credentials.
- If you prefer, I can add some unit tests to present the mistake and the fix. I didn't add them as there are no tests in this part of the code.
