### PR TITLE
Shape data curation for 162, Dw. Wileński 08 -> 09

### DIFF
--- a/data_curated/shapes.json
+++ b/data_curated/shapes.json
@@ -119,6 +119,12 @@
       "to": "435801",
       "via": [52.10678, 20.96913],
       "comment": "L33 for PKP Jeziorki via Raszyńska street"
+    },
+    {
+      "from": "100308",
+      "to": "100309",
+      "via": [52.257858, 21.034591],
+      "comment": "162 for Dworzec Wileński 08 to 09 around the block via 11 Listopada"
     }
   ],
   "ratio_overrides": [


### PR DESCRIPTION
**What**: 

Similar to #81.

Adding bus data curation for 162, the north-bound trips ending in Dw. Wileński to go around via 11 Listopada, then Inżynierska.


**Why**:

- This is how the buses go.
- The current shape doesn't make sense for a bus (a car might in theory go like this if it makes a U-turn in the middle of Wileńska street)

<img width="600" height="1099" alt="wilenski162" src="https://github.com/user-attachments/assets/431c63fe-5079-4c51-a55a-446a1c3cb616" />

